### PR TITLE
double quotes are not needed around the --home and --config params. 

### DIFF
--- a/lib/rsense.rb
+++ b/lib/rsense.rb
@@ -30,7 +30,7 @@ module Redcar
     
     def self.primitive_command
       if Redcar.platform == :windows
-        "java -cp \".;#{RSense.path}/lib/rsense.jar;#{RSense.path}/lib/antlr-runtime-3.2.jar;#{RSense.path}/lib/jruby.jar\" org.cx4a.rsense.Main script \"--home=#{RSense.path}\" --no-prompt --end-mark=END \"--config=#{Redcar.root}/plugins/rsense/.rsense --progress=1\""
+        "java -cp \".;#{RSense.path}/lib/rsense.jar;#{RSense.path}/lib/antlr-runtime-3.2.jar;#{RSense.path}/lib/jruby.jar\" org.cx4a.rsense.Main script --home=#{RSense.path} --no-prompt --end-mark=END --config=#{Redcar.root}/plugins/rsense/.rsense --progress=1"
       else
         "java -cp '.:#{RSense.path}/lib/rsense.jar:#{RSense.path}/lib/antlr-runtime-3.2.jar:#{RSense.path}/lib/jruby.jar' org.cx4a.rsense.Main script '--home=#{RSense.path}' --no-prompt --end-mark=END --config=#{Redcar.root}/plugins/rsense/.rsense --progress=1"
       end


### PR DESCRIPTION
If there are double quotes, it does not use the '.rsense' file and thus does not load the paths on Windows.
